### PR TITLE
Add XDG config directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Snitch obtains credentials from two places:  (default) environment variable or f
 `export GITHUB_PERSONAL_TOKEN = <personal-token>` which can be added to `.bashrc`
 
 ### File
-Resides in `$HOME/.snitch/github.ini`
+Config file can be stored in one of the following directories:
+- `$HOME/.config/snitch/github.ini`
+- `$HOME/.snitch/github.ini`
 
 #### Format
 
@@ -120,7 +122,7 @@ keywords:
 ### Issue Title Transformation
 
 You can apply project local issue title transformations. Create
-`.snich.yaml` file in the root of the project with the following
+`.snitch.yaml` file in the root of the project with the following
 content:
 
 ```yaml

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"gopkg.in/go-ini/ini.v1"
 	"os"
@@ -272,7 +273,8 @@ func locateProject(directory string) (string, error) {
 }
 
 func getGithubCredentials() (GithubCredentials, error) {
-	envar := os.Getenv("GITHUB_PERSONAL_TOKEN")
+	tokenEnvar := os.Getenv("GITHUB_PERSONAL_TOKEN")
+	xdgEnvar := os.Getenv("XDG_CONFIG_HOME")
 	usr, err := user.Current()
 
 	if err != nil {
@@ -280,12 +282,31 @@ func getGithubCredentials() (GithubCredentials, error) {
 		os.Exit(1)
 	}
 
-	if len(envar) != 0 {
-		return GithubCredentialsFromToken(envar), nil
+	if len(tokenEnvar) != 0 {
+		return GithubCredentialsFromToken(tokenEnvar), nil
 	}
 
-	return GithubCredentialsFromFile(
-		path.Join(usr.HomeDir, ".snitch/github.ini"))
+	// custom XDG_CONFIG_HOME
+	if len(xdgEnvar) != 0 {
+		filePath := path.Join(xdgEnvar, "snitch/github.ini")
+		if _, err := os.Stat(filePath); err == nil {
+			return GithubCredentialsFromFile(filePath)
+		}
+	}
+
+	// default XDG_CONFIG_HOME
+	if len(xdgEnvar) == 0 {
+		filePath := path.Join(usr.HomeDir, ".config/snitch/github.ini")
+		if _, err := os.Stat(filePath); err == nil {
+			return GithubCredentialsFromFile(filePath)
+		}
+	}
+
+	if _, err := os.Stat(path.Join(usr.HomeDir, ".snitch/github.ini")); err == nil {
+		return GithubCredentialsFromFile(path.Join(usr.HomeDir, ".snitch/github.ini"))
+	}
+
+	return GithubCredentials{}, errors.New("Configuration file is missing")
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"gopkg.in/go-ini/ini.v1"
 	"os"
@@ -302,11 +301,12 @@ func getGithubCredentials() (GithubCredentials, error) {
 		}
 	}
 
-	if _, err := os.Stat(path.Join(usr.HomeDir, ".snitch/github.ini")); err == nil {
-		return GithubCredentialsFromFile(path.Join(usr.HomeDir, ".snitch/github.ini"))
+	filePath := path.Join(usr.HomeDir, ".snitch/github.ini")
+	if _, err := os.Stat(filePath); err == nil {
+		return GithubCredentialsFromFile(filePath)
 	}
 
-	return GithubCredentials{}, errors.New("Configuration file is missing")
+	return GithubCredentials{}, fmt.Errorf("GitHub token is missing")
 }
 
 func main() {


### PR DESCRIPTION
Config files inside $HOME can create big mess with files and not everyone wants to keep them that way. I added ability to store it in $XDG_CONFIG_HOME (which is ~/.config by default) where most applications' configs are kept.

Also I fixed one small typo in README without creating separate PR