### PR TITLE
Introduce URL alias support

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,10 +195,10 @@ func getURLAliases() (map[string]string, error) {
 
 	for _, elem := range sections {
 		name := elem.Name()
-		isUrlSection := strings.Contains(name, "url")
+		isURLSection := strings.Contains(name, "url")
 		hasHostName := strings.Contains(name, "github") || strings.Contains(name, "gitlab")
 
-		if isUrlSection && hasHostName {
+		if isURLSection && hasHostName {
 			section := cfg.Section(name)
 			key, err := section.GetKey("insteadOf")
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -205,7 +205,10 @@ func getURLAliases() (map[string]string, error) {
 				return map[string]string{}, err
 			}
 
-			aliases[key.Value()] = name[5 : len(name)-1]
+			regex := regexp.MustCompile("[-\\w]+@(github.com|gitlab.com)[^\"]+")
+			resolvedAlias := regex.FindString(name)
+
+			aliases[key.Value()] = resolvedAlias
 		}
 	}
 
@@ -247,6 +250,7 @@ func getRepo(directory string, credentials []IssueAPI) (string, IssueAPI, error)
 	for key, value := range aliases {
 		if strings.Contains(urlString, key) {
 			urlString = strings.Replace(urlString, key, value, 1)
+			break
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -180,14 +180,14 @@ func locateDotGit(dir string) (string, error) {
 func getURLAliases() (map[string]string, error) {
 	usr, err := user.Current()
 	if err != nil {
-		return map[string]string{}, err
+		return map[string]string{}, nil
 	}
 
 	path := path.Join(usr.HomeDir, ".gitconfig")
 
 	cfg, err := ini.Load(path)
 	if err != nil {
-		return map[string]string{}, err
+		return map[string]string{}, nil
 	}
 
 	sections := cfg.Sections()
@@ -203,7 +203,7 @@ func getURLAliases() (map[string]string, error) {
 			section := cfg.Section(elem[0])
 			alias, err := section.GetKey("insteadOf")
 			if err != nil {
-				return map[string]string{}, err
+				return map[string]string{}, nil
 			}
 
 			aliases[alias.Value()] = elem[1]

--- a/main.go
+++ b/main.go
@@ -194,21 +194,19 @@ func getURLAliases() (map[string]string, error) {
 	aliases := map[string]string{}
 
 	for _, elem := range sections {
-		name := elem.Name()
-		isURLSection := strings.Contains(name, "url")
-		hasHostName := strings.Contains(name, "github") || strings.Contains(name, "gitlab")
+		sectionName := elem.Name()
 
-		if isURLSection && hasHostName {
-			section := cfg.Section(name)
-			key, err := section.GetKey("insteadOf")
+		regex := regexp.MustCompile("url \"([-\\w]+@[github.com|gitlab.com][^\"]+)\"")
+		urlSections := regex.FindAllStringSubmatch(sectionName, -1)
+
+		for _, elem := range urlSections {
+			section := cfg.Section(elem[0])
+			alias, err := section.GetKey("insteadOf")
 			if err != nil {
 				return map[string]string{}, err
 			}
 
-			regex := regexp.MustCompile("[-\\w]+@(github.com|gitlab.com)[^\"]+")
-			resolvedAlias := regex.FindString(name)
-
-			aliases[key.Value()] = resolvedAlias
+			aliases[alias.Value()] = elem[1]
 		}
 	}
 


### PR DESCRIPTION
Tries to resolve #151 

There are two ways to create ssh aliases for git
1. in git config -> `~/.gitconfig`
2. in ssh config -> `~/.ssh/config`

Personally I use option 1 and didn't know that there's more ways to do it.

TLDR how my code works:

1. Function returning map of aliases from `~/.gitconfig` is called and does the following:
    1. Opens `~/.gitconfig` as text file to get all section names using regexp
    2. Parses `~/.gitconfig` to get aliases and saves result in map[string]string with format: map['alias'] => url
2. Variable urlString in `getRepo` is checked if contains alias (key from map). If yes, then it's replaced with value from map.

This code isn't top tier (especially my regex) so if there's anything wrong or could be done better, let me know and I will do my best to improve it. If it's overcomplicated or unnecessary, just close PR.
