### PR TITLE
Make Project.WalkTodosOfDir concurrent

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,30 +42,32 @@ func listSubcommand(project Project, filter func(todo Todo) bool) error {
 }
 
 func reportSubcommand(project Project, creds IssueAPI, repo string, prependBody string) error {
-	todosToReport := []Todo{}
+	todosToAsk := []Todo{}
 
 	err := project.WalkTodosOfDir(".", func(todo Todo) error {
 		if todo.ID == nil {
-			fmt.Printf("%v\n", todo.LogString())
-			fmt.Printf("Issue Title: %s\n", todo.Title)
-			for _, bodyLine := range todo.Body {
-				fmt.Printf("  %s\n", bodyLine)
-			}
-
-			yes, err := yOrN("Do you want to report this? ")
-
-			if yes {
-				todosToReport = append(todosToReport, todo)
-			}
-
-			return err
+			todosToAsk = append(todosToAsk, todo)
 		}
-
 		return nil
 	})
-
 	if err != nil {
 		return err
+	}
+
+	todosToReport := []Todo{}
+	for _, todo := range todosToAsk {
+		fmt.Printf("%v\n", todo.LogString())
+		fmt.Printf("Issue Title: %s\n", todo.Title)
+		for _, bodyLine := range todo.Body {
+			fmt.Printf("  %s\n", bodyLine)
+		}
+
+		yes, err := yOrN("Do you want to report this? ")
+		if err != nil {
+			return err
+		} else if yes {
+			todosToReport = append(todosToReport, todo)
+		}
 	}
 
 	for _, todo := range todosToReport {

--- a/main.go
+++ b/main.go
@@ -43,7 +43,9 @@ func listSubcommand(project Project, filter func(todo Todo) bool) error {
 			cancel()
 			return v.err
 		}
-		fmt.Println(v.todo.LogString())
+		if filter(*v.todo) {
+			fmt.Println(v.todo.LogString())
+		}
 	}
 
 	return nil

--- a/project.go
+++ b/project.go
@@ -213,7 +213,6 @@ func (project Project) WalkTodosOfDir(dirpath string, visit func(todo Todo) erro
 		sem.Acquire(ctx, 1)
 		g.Go(func() error {
 			defer sem.Release(1)
-			// FIXME: Don't visit a path if it's other than source code (e.g. images, music)
 			return project.WalkTodosOfFile(filepath, visit)
 		})
 	}

--- a/project.go
+++ b/project.go
@@ -200,6 +200,7 @@ func (project Project) WalkTodosOfDir(dirpath string, visit func(todo Todo) erro
 		go func() {
 			defer workers.Done()
 
+			var workerErr error
 			var stat os.FileInfo
 			for filepath := range work {
 				select {
@@ -208,8 +209,9 @@ func (project Project) WalkTodosOfDir(dirpath string, visit func(todo Todo) erro
 				default:
 				}
 
-				stat, err = os.Stat(filepath)
-				if err != nil {
+				stat, workerErr = os.Stat(filepath)
+				if workerErr != nil {
+					err = workerErr
 					cancel()
 					return
 				}
@@ -219,7 +221,8 @@ func (project Project) WalkTodosOfDir(dirpath string, visit func(todo Todo) erro
 					continue
 				}
 
-				if err = project.WalkTodosOfFile(filepath, visit); err != nil {
+				if workerErr = project.WalkTodosOfFile(filepath, visit); err != nil {
+					err = workerErr
 					cancel()
 				}
 			}

--- a/project.go
+++ b/project.go
@@ -221,7 +221,7 @@ func (project Project) WalkTodosOfDir(dirpath string, visit func(todo Todo) erro
 					continue
 				}
 
-				if workerErr = project.WalkTodosOfFile(filepath, visit); err != nil {
+				if workerErr = project.WalkTodosOfFile(filepath, visit); workerErr != nil {
 					err = workerErr
 					cancel()
 				}

--- a/project.go
+++ b/project.go
@@ -192,7 +192,7 @@ func (project Project) WalkTodosOfDir(dirpath string, visit func(todo Todo) erro
 	}
 
 	g, ctx := errgroup.WithContext(context.Background())
-	// FIXME: Arbitrary max weight for preventing "too many open files" error
+	// FIXME: Find the max weight for preventing "too many open files" error
 	// This has to do with big projects and the limit of number of open file
 	// descriptors that a process may have at any given time.
 	sem := semaphore.NewWeighted(1024)


### PR DESCRIPTION
Possibly fixes #153

Only `snitch purge` and `snitch report` are partly concurrent, the HTTP requests remain sequential. This could be made concurrent as well but maybe not desired.

I've implemented this with a worker pool like pattern. Limiting the amount of files being walked at a given time. Since it will report an error about exceeding the open file descriptors limit on *very large* projects. I've hardcoded this value for now to the default soft limit on linux. But maybe we should get the value from `ulimit` and use that instead? (What about other platforms?)

Furthermore I noticed that snitch doesn't ignore non-source-code paths e.g. image paths. I've put a FIXME above the line. Possibly have an option in the config for blacklisting file extensions.