### PR TITLE
Fix TODO body being the whole file when prefix is empty

### DIFF
--- a/project.go
+++ b/project.go
@@ -46,7 +46,7 @@ func (titleConfig *TitleConfig) Transform(title string) string {
 // Project contains the project level configuration
 type Project struct {
 	Title    *TitleConfig
-	Keywords []string
+	Keywords []string `yaml:"omitempty"`
 }
 
 func unreportedTodoRegexp(keyword string) string {


### PR DESCRIPTION
Fix #138

Adds yaml `omitempty` flag to Project struct to ignore empty prefix keywords. Taken from the [docs](https://pkg.go.dev/gopkg.in/yaml.v2?tab=doc#Marshal).