### PR TITLE
Add Support for Windows file system.

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,17 +177,18 @@ func usage() {
 
 func locateDotGit(dir string) (string, error) {
 	absDir, err := filepath.Abs(dir)
+	rooted := ""
 	if err != nil {
 		return "", err
 	}
-
-	for absDir != "/" {
+	
+	for absDir != rooted {
 		dotGit := path.Join(absDir, ".git")
 
 		if stat, err := os.Stat(dotGit); !os.IsNotExist(err) && stat.IsDir() {
 			return dotGit, nil
 		}
-
+		rooted = absDir
 		absDir = filepath.Dir(absDir)
 	}
 

--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func locateDotGit(dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	for absDir != rooted {
 		dotGit := path.Join(absDir, ".git")
 


### PR DESCRIPTION
Windows is sad because root is c:\ not /.  Without this change snitch is forever recursive if .git is not in the
path tree. 
Tested successfully on Windows and Linux.