### PR TITLE
Introduce new cli mechanism

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var commands []command
+
+type command struct {
+	name, desc string
+	flags      *flag.FlagSet
+	action     func() error
+}
+
+func addSubCommand(flags *flag.FlagSet, desc string, action func() error) {
+	commands = append(commands, command{
+		name:   flags.Name(),
+		desc:   desc,
+		flags:  flags,
+		action: action,
+	})
+}
+
+var (
+	errNoCommandSpecified = errors.New("no command specified")
+	errUknownCommand      = errors.New("unknown command")
+	errCommandFailed      = errors.New("command failed")
+)
+
+func run(args []string) error {
+	if len(args) <= 1 {
+		printUsage()
+		return errNoCommandSpecified
+	}
+
+	var cmd *command
+	for _, v := range commands {
+		if v.name == args[1] {
+			cmd = &v
+			break
+		}
+	}
+
+	if cmd == nil {
+		return fmt.Errorf("%s: %w", strings.Join(args, " "), errUknownCommand)
+	}
+
+	cmd.flags.Parse(args[2:])
+	if err := cmd.action(); err != nil {
+		return fmt.Errorf("%s: snitch %s: %w", err, cmd.name, errCommandFailed)
+	}
+
+	return nil
+}
+
+func printUsage() {
+	sort.SliceStable(commands, func(i, j int) bool {
+		return strings.Compare(commands[i].name, commands[j].name) == -1
+	})
+
+	fmt.Println("snitch [opt]")
+
+	for _, cmd := range commands {
+		fmt.Printf("\t%s", cmd.name)
+
+		cmd.flags.VisitAll(func(f *flag.Flag) {
+			name, _ := flag.UnquoteUsage(f)
+
+			if len(name) == 0 {
+				fmt.Printf(" [--%s]", f.Name)
+			} else {
+				fmt.Printf(" [--%s <%s>]", f.Name, name)
+			}
+		})
+
+		fmt.Printf(": %s\n", cmd.desc)
+	}
+}

--- a/github.go
+++ b/github.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"gopkg.in/go-ini/ini.v1"
 	"net/http"
@@ -125,5 +126,5 @@ func getGithubCredentials() (GithubCredentials, error) {
 		return GithubCredentialsFromFile(filePath)
 	}
 
-	return GithubCredentials{}, fmt.Errorf("GitHub token is missing")
+	return GithubCredentials{}, errors.New("GitHub token is missing")
 }

--- a/github.go
+++ b/github.go
@@ -20,6 +20,9 @@ type GithubCredentials struct {
 func (creds GithubCredentials) query(method, url string, jsonBody map[string]interface{}) (map[string]interface{}, error) {
 	bodyBuffer := new(bytes.Buffer)
 	err := json.NewEncoder(bodyBuffer).Encode(jsonBody)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest(method, url, bodyBuffer)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -326,10 +326,11 @@ func main() {
 		listCmdUnreported = listCmd.Bool("unreported", false, "list unreported todos")
 	)
 	addSubCommand(listCmd, "lists all todos of a dir recursively", func() error {
+		r, u := *listCmdReported, *listCmdUnreported
+
 		return listSubcommand(*project, func(todo Todo) bool {
-			return *listCmdReported == *listCmdUnreported ||
-				(*listCmdReported && todo.ID != nil) ||
-				(*listCmdUnreported && todo.ID == nil)
+			ok := todo.ID != nil
+			return r == u || (r && ok) || (u && !ok)
 		})
 	})
 

--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func locateDotGit(dir string) (string, error) {
 		absDir = filepath.Dir(absDir)
 	}
 
-	return "", fmt.Errorf("Couldn't find .git. Maybe you are not inside of a git repo")
+	return "", errors.New("Couldn't find .git. Maybe you are not inside of a git repo")
 }
 
 func getURLAliases() (map[string]string, error) {
@@ -232,7 +232,7 @@ func getURLAliases() (map[string]string, error) {
 func getRepo(directory string) (string, IssueAPI, error) {
 	credentials := getCredentials()
 	if len(credentials) == 0 {
-		return "", nil, fmt.Errorf("No credentials have been found. Read https://github.com/tsoding/snitch#credentials")
+		return "", nil, errors.New("No credentials have been found. Read https://github.com/tsoding/snitch#credentials")
 	}
 
 	dotGit, err := locateDotGit(directory)
@@ -249,13 +249,13 @@ func getRepo(directory string) (string, IssueAPI, error) {
 
 	origin := cfg.Section("remote \"origin\"")
 	if origin == nil {
-		return "", nil, fmt.Errorf("The git repo doesn't have any origin remote. " +
+		return "", nil, errors.New("The git repo doesn't have any origin remote. " +
 			"Please use `git remote add' command to add one.")
 	}
 
 	url := origin.Key("url")
 	if url == nil {
-		return "", nil, fmt.Errorf("The origin remote doesn't have any URL's " +
+		return "", nil, errors.New("The origin remote doesn't have any URL's " +
 			"associated with it.")
 	}
 


### PR DESCRIPTION
Resolves #9 by proposing a new declarative way of configuring the sub-commands (list, purge & report).
This new mechanism is a thin layer around the existing std `flag` package for command-line flag parsing.
I tried to make it as simple as possible for the current set of commands whilst keeping the previous behavior.