### PR TITLE
Integrate Gitea self hosted git with snitch

### DIFF
--- a/gitea.go
+++ b/gitea.go
@@ -36,6 +36,7 @@ func (creds GiteaCredentials) query(method, url string, jsonBody map[string]inte
 }
 
 func (creds GiteaCredentials) getIssue(repo string, todo Todo) (map[string]interface{}, error) {
+	// FIXME(#187): gitea integration does not support http instances.
 	json, err := creds.query(
 		"GET",
 		"https://"+creds.Host+"/api/v1/repos/"+repo+"/issues/"+(*todo.ID)[1:],

--- a/gitea.go
+++ b/gitea.go
@@ -94,15 +94,15 @@ func GiteaCredentialsFromToken(token string) (GiteaCredentials, error) {
 	credentials := strings.Split(token, ":")
 
 	switch len(credentials) {
-	case 1:
-		return GiteaCredentials{
-			Host:          "gitea.com",
-			PersonalToken: credentials[0],
-		}, nil
 	case 2:
 		return GiteaCredentials{
 			Host:          credentials[0],
 			PersonalToken: credentials[1],
+		}, nil
+	case 3:
+		return GiteaCredentials{
+			Host:          credentials[0] + ":" + credentials[1],
+			PersonalToken: credentials[2],
 		}, nil
 	default:
 		return GiteaCredentials{},

--- a/gitea.go
+++ b/gitea.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+	"strings"
+
+	"gopkg.in/go-ini/ini.v1"
+)
+
+// GiteaCredentials contains PersonalToken for GitLab API authorization
+// and Host for possibly implementing support for self-hosted instances
+type GiteaCredentials struct {
+	Host          string
+	PersonalToken string
+}
+
+func (creds GiteaCredentials) query(method, url string) (map[string]interface{}, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("TOKEN", creds.PersonalToken)
+
+	return QueryHTTP(req)
+}
+
+func (creds GiteaCredentials) getIssue(repo string, todo Todo) (map[string]interface{}, error) {
+	json, err := creds.query(
+		"GET",
+		"http://"+creds.Host+"/api/v1/repos/"+url.QueryEscape(repo)+"/issues/"+(*todo.ID)[1:]) // self-hosted
+
+	if err != nil {
+		return nil, err
+	}
+
+	return json, nil
+}
+
+func (creds GiteaCredentials) postIssue(repo string, todo Todo, body string) (Todo, error) {
+	params := url.Values{}
+	params.Add("title", todo.Title)
+	params.Add("description", body)
+
+	json, err := creds.query(
+		"POST",
+		"https://"+creds.Host+"/api/v1/repos/"+url.QueryEscape(repo)+"/issues?"+params.Encode()) // self-hosted
+	if err != nil {
+		return todo, err
+	}
+
+	id := "#" + strconv.Itoa(int(json["iid"].(float64)))
+	todo.ID = &id
+
+	return todo, err
+}
+
+func (creds GiteaCredentials) getHost() string {
+	return creds.Host
+}
+
+// GiteaCredentialsFromFile gets GiteaCredentials from a filepath
+func GiteaCredentialsFromFile(filepath string) []GiteaCredentials {
+	credentials := []GiteaCredentials{}
+
+	cfg, err := ini.Load(filepath)
+	if err != nil {
+		return credentials
+	}
+
+	for _, section := range cfg.Sections()[1:] {
+		credentials = append(credentials, GiteaCredentials{
+			Host:          section.Name(),
+			PersonalToken: section.Key("personal_token").String(),
+		})
+	}
+
+	return credentials
+}
+
+// GiteaCredentialsFromToken returns a GiteaCredentials from a string token
+func GiteaCredentialsFromToken(token string) (GiteaCredentials, error) {
+	credentials := strings.Split(token, ":")
+
+	switch len(credentials) {
+	case 1:
+		return GiteaCredentials{
+			Host:          "gitlab.com",
+			PersonalToken: credentials[0],
+		}, nil
+	case 2:
+		return GiteaCredentials{
+			Host:          credentials[0],
+			PersonalToken: credentials[1],
+		}, nil
+	default:
+		return GiteaCredentials{},
+			fmt.Errorf("Couldn't parse GitLab credentials from ENV: %s", token)
+	}
+
+}
+
+func getGiteaCredentials(creds []IssueAPI) []IssueAPI {
+	tokenEnvar := os.Getenv("GITLAB_PERSONAL_TOKEN")
+	xdgEnvar := os.Getenv("XDG_CONFIG_HOME")
+	usr, err := user.Current()
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if len(tokenEnvar) != 0 {
+		for _, credential := range strings.Split(tokenEnvar, ",") {
+			parsedCredentials, err := GiteaCredentialsFromToken(credential)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				continue
+			}
+			creds = append(creds, parsedCredentials)
+		}
+	}
+
+	// custom XDG_CONFIG_HOME
+	if len(xdgEnvar) != 0 {
+		filePath := path.Join(xdgEnvar, "snitch/gitlab.ini")
+		if _, err := os.Stat(filePath); err == nil {
+			for _, cred := range GiteaCredentialsFromFile(filePath) {
+				creds = append(creds, cred)
+			}
+		}
+	}
+
+	// default XDG_CONFIG_HOME
+	if len(xdgEnvar) == 0 {
+		filePath := path.Join(usr.HomeDir, ".config/snitch/gitlab.ini")
+		if _, err := os.Stat(filePath); err == nil {
+			for _, cred := range GiteaCredentialsFromFile(filePath) {
+				creds = append(creds, cred)
+			}
+		}
+	}
+
+	filePath := path.Join(usr.HomeDir, ".snitch/gitlab.ini")
+	if _, err := os.Stat(filePath); err == nil {
+		for _, cred := range GiteaCredentialsFromFile(filePath) {
+			creds = append(creds, cred)
+		}
+	}
+
+	return creds
+}

--- a/gitea.go
+++ b/gitea.go
@@ -38,7 +38,7 @@ func (creds GiteaCredentials) query(method, url string, jsonBody map[string]inte
 func (creds GiteaCredentials) getIssue(repo string, todo Todo) (map[string]interface{}, error) {
 	json, err := creds.query(
 		"GET",
-		"http://"+creds.Host+"/api/v1/repos/"+repo+"/issues/"+(*todo.ID)[1:],
+		"https://"+creds.Host+"/api/v1/repos/"+repo+"/issues/"+(*todo.ID)[1:],
 		nil) // self-hosted
 
 	if err != nil {
@@ -51,7 +51,7 @@ func (creds GiteaCredentials) getIssue(repo string, todo Todo) (map[string]inter
 func (creds GiteaCredentials) postIssue(repo string, todo Todo, body string) (Todo, error) {
 	json, err := creds.query(
 		"POST",
-		"http://"+creds.Host+"/api/v1/repos/"+repo+"/issues",
+		"https://"+creds.Host+"/api/v1/repos/"+repo+"/issues",
 		map[string]interface{}{
 			"title": todo.Title,
 			"body":  body,

--- a/gitea.go
+++ b/gitea.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"os/user"
 	"path"
@@ -39,7 +38,7 @@ func (creds GiteaCredentials) query(method, url string, jsonBody map[string]inte
 func (creds GiteaCredentials) getIssue(repo string, todo Todo) (map[string]interface{}, error) {
 	json, err := creds.query(
 		"GET",
-		"http://"+creds.Host+"/api/v1/repos/"+url.QueryEscape(repo)+"/issues/"+(*todo.ID)[1:],
+		"http://"+creds.Host+"/api/v1/repos/"+repo+"/issues/"+(*todo.ID)[1:],
 		nil) // self-hosted
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"gopkg.in/go-ini/ini.v1"
 	"os"
 	"os/user"
 	"path"
@@ -11,6 +10,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"gopkg.in/go-ini/ini.v1"
 )
 
 func yOrN(question string) (bool, error) {
@@ -359,7 +360,7 @@ func getCredentials() []IssueAPI {
 		creds = append(creds, github)
 	}
 	creds = getGitlabCredentials(creds)
-
+	creds = getGiteaCredentials(creds)
 	return creds
 }
 


### PR DESCRIPTION
Hi @rexim,
The following PR integrates Gitea with snitch. 

### Gitea Credentials
Gitea configuration is similar to GitLab where you need to provide the host of the Gitea instance as well as the access-token.

#### Environmental Variable
`export GITEA_ACCESS_TOKEN = <host>:<access-token>` which can be added to .`bashrc`.

Each of the credentials are to be separated by `,` and in format: `<host>:<access-token>` or `<host>:<port>:<access-token>`. Credentials without host part, e.g. `<access-token>` are not allowed and invalid tokens are ignored (prints an error message). 

#### File
Config file can be stored in one of the following directories:

-` $HOME/.config/snitch/gitea.ini`
-` $HOME/.snitch/gitea.ini`

Format:
```
[hostname1]
access_token = <access_token>

[hostname2:port]
access_token = <access_token>
```
[Gitea Api Usage](https://docs.gitea.io/en-us/api-usage/) explains how to create an access token.