### PR TITLE
Fix Go version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - go get -v .
   - go get -u golang.org/x/lint/golint
 script:
-  - diff <(gofmt -d .) <(echo -n)
+  - diff --line-format=%L <(gofmt -d .) <(echo -n)
   - go vet -x ./...
   - golint -set_exit_status ./...
   - go build -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.9.x
+  - stable
 install:
   - go get github.com/tsoding/snitch
   - go get -v .


### PR DESCRIPTION
- Uses recent stable Go version, same behavior as in GitHub Actions workflow file
- Fix leading "<" in diff script

Related #184 

👕.
