### PR TITLE
Fix invalid issue enumeration in gitea.go

### DIFF
--- a/gitea.go
+++ b/gitea.go
@@ -61,7 +61,7 @@ func (creds GiteaCredentials) postIssue(repo string, todo Todo, body string) (To
 		return todo, err
 	}
 
-	id := "#" + strconv.Itoa(int(json["id"].(float64)))
+	id := "#" + strconv.Itoa(int(json["number"].(float64)))
 	todo.ID = &id
 
 	return todo, err


### PR DESCRIPTION
c39268668400516b4f9e8a6c79775dda57ef3e72 produced a subtle error in referencing the `["id"]` key as opposed to the `["number"]` key.

 This caused issues reported in gitea projects to be numbered improperly. 

