### PR TITLE
(#203) Fix permissions issue

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -66,10 +66,10 @@ func (todo Todo) updateToFile(outputFilename string, lineCallback func(int, stri
 	}
 	defer inputFile.Close()
 
-  fileInfo, err := os.Stat(todo.Filename)
-  if err != nil {
-    return err
-  }
+	fileInfo, err := os.Stat(todo.Filename)
+	if err != nil {
+		return err
+	}
 
 	outputFile, err := os.Create(outputFilename)
 	if err != nil {
@@ -96,10 +96,10 @@ func (todo Todo) updateToFile(outputFilename string, lineCallback func(int, stri
 		lineNumber = lineNumber + 1
 	}
 
-  err = outputFile.Chmod(fileInfo.Mode())
-  if err != nil {
-    return err
-  }
+	err = outputFile.Chmod(fileInfo.Mode())
+	if err != nil {
+		return err
+	}
 
 	return err
 }

--- a/todo.go
+++ b/todo.go
@@ -66,6 +66,11 @@ func (todo Todo) updateToFile(outputFilename string, lineCallback func(int, stri
 	}
 	defer inputFile.Close()
 
+  fileInfo, err := os.Stat(todo.Filename)
+  if err != nil {
+    return err
+  }
+
 	outputFile, err := os.Create(outputFilename)
 	if err != nil {
 		return err
@@ -90,6 +95,11 @@ func (todo Todo) updateToFile(outputFilename string, lineCallback func(int, stri
 
 		lineNumber = lineNumber + 1
 	}
+
+  _, err := outputFile.Chmod(fileInfo.Mode())
+  if err != nil {
+    return err
+  }
 
 	return err
 }

--- a/todo.go
+++ b/todo.go
@@ -96,7 +96,7 @@ func (todo Todo) updateToFile(outputFilename string, lineCallback func(int, stri
 		lineNumber = lineNumber + 1
 	}
 
-  _, err := outputFile.Chmod(fileInfo.Mode())
+  err = outputFile.Chmod(fileInfo.Mode())
   if err != nil {
     return err
   }


### PR DESCRIPTION
Fixes #203.

Now executable files that are being reported are going to preserve their executable bit. We basically just copy permissions from input file to the output file by doing `os.Chmod`.

You can also check https://github.com/aodhneine/snitch-lab that shows that `test-executable` is commited with the executable flag set.