### PR TITLE
(#205) Use os.Chmod instead of file.Chmod for compat with Windows

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -96,7 +96,7 @@ func (todo Todo) updateToFile(outputFilename string, lineCallback func(int, stri
 		lineNumber = lineNumber + 1
 	}
 
-	err = outputFile.Chmod(fileInfo.Mode())
+	err = os.Chmod(outputFilename, fileInfo.Mode());
 	if err != nil {
 		return err
 	}

--- a/todo.go
+++ b/todo.go
@@ -96,7 +96,7 @@ func (todo Todo) updateToFile(outputFilename string, lineCallback func(int, stri
 		lineNumber = lineNumber + 1
 	}
 
-	err = os.Chmod(outputFilename, fileInfo.Mode());
+	err = os.Chmod(outputFilename, fileInfo.Mode())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#205 