### PR TITLE
Remove concurrency in WalkTodosOfDir

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,10 @@ func listSubcommand(project Project, filter func(todo Todo) bool) error {
 func reportSubcommand(project Project, creds IssueAPI, repo string, prependBody string, alwaysYes bool) error {
 	todosToReport := []*Todo{}
 	err := project.WalkTodosOfDir(".", func(todo Todo) error {
+		if todo.ID != nil {
+			return nil
+		}
+
 		fmt.Printf("%v\n", todo.LogString())
 		fmt.Printf("Issue Title: %s\n", todo.Title)
 		for _, bodyLine := range todo.Body {

--- a/main.go
+++ b/main.go
@@ -44,12 +44,12 @@ func listSubcommand(project Project, filter func(todo Todo) bool) error {
 			fmt.Println(todo.LogString())
 		}
 		return nil
-	});
+	})
 }
 
 func reportSubcommand(project Project, creds IssueAPI, repo string, prependBody string, alwaysYes bool) error {
 	todosToReport := []*Todo{}
-	err := project.WalkTodosOfDir(".", func (todo Todo) error {
+	err := project.WalkTodosOfDir(".", func(todo Todo) error {
 		fmt.Printf("%v\n", todo.LogString())
 		fmt.Printf("Issue Title: %s\n", todo.Title)
 		for _, bodyLine := range todo.Body {
@@ -95,7 +95,7 @@ func reportSubcommand(project Project, creds IssueAPI, repo string, prependBody 
 
 func purgeSubcommand(project Project, creds IssueAPI, repo string, alwaysYes bool) error {
 	todosToRemove := []*Todo{}
-	err := project.WalkTodosOfDir(".", func (todo Todo) error {
+	err := project.WalkTodosOfDir(".", func(todo Todo) error {
 		if todo.ID == nil {
 			return nil
 		}


### PR DESCRIPTION
It sped up the process of the file system traversal a bit, but not
enough to justify the complication of the code, IMO. And it didn't
really matter that much in case of `report` and `purge` subcommands
because they are interactive and constantly stop for the user feedback
anyway.

A proper investigation of an actual bottleneck is required here, so we
can come up with the simplest most maintainable solution.