### PR TITLE
Include TODO's title into commit message

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -157,7 +157,7 @@ func (todo Todo) GitCommit(prefix string) error {
 		return err
 	}
 
-	if err := LogCommand(exec.Command("git", "commit", "-m", fmt.Sprintf("%s %s(%s)", prefix, todo.Keyword, *todo.ID))).Run(); err != nil {
+	if err := LogCommand(exec.Command("git", "commit", "-m", fmt.Sprintf("%s %s(%s): %s", prefix, todo.Keyword, *todo.ID, todo.Title))).Run(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I’ve been using Snitch for the past few months, and the tool is really great. 
However, I always wanted to include the TODO’s title in the commit messages to make them a bit prettier. So I figured you might want this too.